### PR TITLE
Add breaking change note to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 # [2.4.0](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/compare/v2.3.0...v2.4.0) (2023-08-30)
 
+### Breaking
+
+* **Pluto:** removed Pluto implementation from main bundle
 
 ### Bug Fixes
 


### PR DESCRIPTION
When this code became open source, I was able to pull from source instead of using a bootleg version from a collaborator who'd been given access.

Today I was seeing some bug in our tests and realised I might be running outdated code. Installing this package for node simply is another issue (#96), but once I had it installed I discovered a **breaking change** to the API ... within a **minor semver release**.

:fire: :skull: :sob: 

Is this project running semver? If yes, please be more careful :heart:
I don't want people to be put off your hard work because of lots of minor cuts like this