### PR TITLE
feat: extending Agent.acceptInvitation to handle OOB + Prism

### DIFF
--- a/demos/browser/src/App.tsx
+++ b/demos/browser/src/App.tsx
@@ -350,7 +350,7 @@ const OOB: React.FC<{ agent: SDK.Agent, pluto: SDK.Domain.Pluto; }> = props => {
       return;
     }
     const parsed = await props.agent.parseOOBInvitation(new URL(oob));
-    await props.agent.acceptDIDCommInvitation(parsed);
+    await props.agent.acceptInvitation(parsed);
   }
 
   const connection = connections.at(0);

--- a/src/prism-agent/Agent.Invitations.ts
+++ b/src/prism-agent/Agent.Invitations.ts
@@ -66,6 +66,18 @@ export class AgentInvitations implements AgentInvitationsClass {
     throw new AgentError.UnknownInvitationTypeError();
   }
 
+  async acceptInvitation(invitation: InvitationType): Promise<void> {
+    if (invitation.type === ProtocolType.Didcomminvitation) {
+      return this.acceptDIDCommInvitation(invitation);
+    }
+
+    if (invitation instanceof PrismOnboardingInvitation) {
+      return this.acceptPrismOnboardingInvitation(invitation);
+    }
+
+    throw new AgentError.InvitationIsInvalidError();
+  }
+
   /**
    * Asyncronously accept a didcomm v2 invitation, will create a pair between the Agent
    *  its connecting with and the current owner's did
@@ -101,7 +113,7 @@ export class AgentInvitations implements AgentInvitationsClass {
    * @param {PrismOnboardingInvitation} invitation
    * @returns {Promise<void>}
    */
-  async acceptInvitation(invitation: PrismOnboardingInvitation): Promise<void> {
+  async acceptPrismOnboardingInvitation(invitation: PrismOnboardingInvitation): Promise<void> {
     if (!invitation.from) {
       throw new AgentError.UnknownInvitationTypeError();
     }

--- a/src/prism-agent/Agent.ts
+++ b/src/prism-agent/Agent.ts
@@ -55,10 +55,9 @@ interface AgentConfig {
  */
 export default class Agent
   implements
-    AgentCredentialsClass,
-    AgentDIDHigherFunctionsClass,
-    AgentInvitationsClass
-{
+  AgentCredentialsClass,
+  AgentDIDHigherFunctionsClass,
+  AgentInvitationsClass {
   /**
    * Agent state
    *
@@ -289,13 +288,13 @@ export default class Agent
   }
 
   /**
-   * Asyncronously accept a prism onboarding invitation, used to onboard the current did in a prism agent.
-   *
+   * Handle an invitation to create a connection
+   * 
    * @async
-   * @param {PrismOnboardingInvitation} invitation
+   * @param {InvitationType} invitation - an OOB or PrismOnboarding invitation
    * @returns {Promise<void>}
    */
-  async acceptInvitation(invitation: PrismOnboardingInvitation): Promise<void> {
+  async acceptInvitation(invitation: InvitationType): Promise<void> {
     return this.agentInvitations.acceptInvitation(invitation);
   }
 
@@ -337,6 +336,7 @@ export default class Agent
    * Asyncronously accept a didcomm v2 invitation, will create a pair between the Agent
    *  its connecting with and the current owner's did
    *
+   * @deprecated - use `acceptInvitation`
    * @async
    * @param {OutOfBandInvitation} invitation
    * @returns {*}


### PR DESCRIPTION
# Description
Extending acceptInvitation to handle both OOB and Prism invitations.
Marking acceptDIDCommInvitation as deprecated.
Updating Browser Demo to use acceptInvitation


# Jira link
https://input-output.atlassian.net/browse/ATL-4064

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [ ] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually
