### PR TITLE
docs: Introduced breaking changes in Pluto as we are intro…

### DIFF
--- a/src/domain/buildingBlocks/Pluto.ts
+++ b/src/domain/buildingBlocks/Pluto.ts
@@ -15,15 +15,24 @@ import { Anoncreds } from "../models/Anoncreds";
  *
  */
 export interface Pluto {
+  /**
+   * Store the AnonCreds Credential Metadata referencing its linkSecret name
+   */
   storeCredentialMetadata(
     metadata: Anoncreds.CredentialRequestMeta,
     linkSecret: Anoncreds.LinkSecret
   ): Promise<void>;
 
+  /**
+   * Fetch the AnonCreds Credential Metadata by its linkSecret name
+   */
   fetchCredentialMetadata(
     linkSecretName: string
   ): Promise<Anoncreds.CredentialRequestMeta | null>;
 
+  /**
+   * Pluto initialise function
+   */
   start(): Promise<void>;
 
   /**
@@ -72,6 +81,9 @@ export interface Pluto {
    */
   storeMediator(mediator: DID, host: DID, routing: DID): Promise<void>;
 
+  /**
+   * Store a Credential into the Database
+   */
   storeCredential(credential: Credential): Promise<void>;
 
   /**
@@ -184,10 +196,19 @@ export interface Pluto {
    */
   getAllMediators(): Promise<Array<Mediator>>;
 
+  /**
+   * Retrieve all the stored credentials
+   */
   getAllCredentials(): Promise<Array<Credential>>;
 
+  /**
+   * Retrieve the anoncreds stored link secret by its name
+   */
   getLinkSecret(linkSecretName?: string): Promise<Anoncreds.LinkSecret | null>;
 
+  /**
+   * Store a new anoncreds linkSecret
+   */
   storeLinkSecret(
     linkSecret: Anoncreds.LinkSecret,
     linkSecretName: string


### PR DESCRIPTION
We are about to release prism 2.6 and as reported by a user we have missed introducing the breaking change in Pluto. Despite Pluto is not part of our bundle anymore, we do cause disruption with existing users and the correct is to apply the breaking change.

Only positive thing is that 2.5.0 is part of 2.6 prism release which is not yet released, its a draft release.

This PR does not introduce the breaking change but just applies the configuration and doc changes.
- X25519 keys were wrongly set as EC (elliptic) key types which is wrong. EC25519 + Secp256k1 belong to EC key type, X25519 should have Curve25519 instead to be valid. If you previously had a key stored as EC (x25519) changing that keyType to KeyTypes.X25519 (Curve25519).
- As we have introduced new credential types we have also built a credential abstraction so storing and fetching credentials becomes easier.

