### PR TITLE
fix: Update demos to use the new Mediator peer did

### DIFF
--- a/demos/browser/src/App.tsx
+++ b/demos/browser/src/App.tsx
@@ -20,7 +20,7 @@ const RequestPresentation = SDK.RequestPresentation;
 
 const apollo = new SDK.Apollo();
 const castor = new SDK.Castor(apollo);
-const defaultMediatorDID = "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9zaXQtcHJpc20tbWVkaWF0b3IuYXRhbGFwcmlzbS5pbyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0";
+const defaultMediatorDID = "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9zaXQtcHJpc20tbWVkaWF0b3IuYXRhbGFwcmlzbS5pbyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0.SeyJ0IjoiZG0iLCJzIjoid3NzOi8vc2l0LXByaXNtLW1lZGlhdG9yLmF0YWxhcHJpc20uaW8vd3MiLCJyIjpbXSwiYSI6WyJkaWRjb21tL3YyIl19";
 const pluto = new PlutoInMemory();
 
 const useSDK = (mediatorDID: SDK.Domain.DID) => {
@@ -491,7 +491,7 @@ const Agent: React.FC<{}> = props => {
 
       );
     }
-    catch (e) {}
+    catch (e) { }
   };
 
   const handleStop = async () => {

--- a/demos/node/src/index.ts
+++ b/demos/node/src/index.ts
@@ -34,7 +34,7 @@ function createTestScenario(mediatorDID: SDK.Domain.DID) {
 
 (async () => {
   const mediatorDID = SDK.Domain.DID.fromString(
-    "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9zaXQtcHJpc20tbWVkaWF0b3IuYXRhbGFwcmlzbS5pbyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0",
+    "did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9zaXQtcHJpc20tbWVkaWF0b3IuYXRhbGFwcmlzbS5pbyIsInIiOltdLCJhIjpbImRpZGNvbW0vdjIiXX0.SeyJ0IjoiZG0iLCJzIjoid3NzOi8vc2l0LXByaXNtLW1lZGlhdG9yLmF0YWxhcHJpc20uaW8vd3MiLCJyIjpbXSwiYSI6WyJkaWRjb21tL3YyIl19"
   );
 
   const { seed, agent } = createTestScenario(mediatorDID);


### PR DESCRIPTION


# Description
Simply changing peer dids in the demo to use the last encoding in the mediators peerDID which is adding an extra service to use websockets as transport over http.

# Jira link
N/A

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually
