### PR TITLE
fix:  expose functionality to create peerDIDs outside of the agent.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from "./mercury/didcomm/Wrapper";
 export * from "./prism-agent/helpers/ApiImpl";
 export { ListenerKey } from "./prism-agent/types";
 
+export * from './peer-did/PeerDIDCreate';
 export type {
   MediatorHandler,
   ConnectionsManager as ConnectionsManagerInterface,


### PR DESCRIPTION
I would like to propose to expose the peerdid create function and make it available as part of the bundle in order to be able to create peerdids from existing keys outside of the agent.

The new exportes classes had been documented in the past so they are okey.


# Description
No PR, this is an open proposal of improvement.

# Jira link
N/A

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [ ] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
