### PR TITLE
fix: typos InvalidBasicMEssageBodyError and signasture

### DIFF
--- a/src/domain/models/errors/Agent.ts
+++ b/src/domain/models/errors/Agent.ts
@@ -60,7 +60,7 @@ export class InvalidProposePresentationBodyError extends Error {
     super(message || "Invalid ProposePresentation body Error");
   }
 }
-export class InvalidBasicMEssageBodyError extends Error {
+export class InvalidBasicMessageBodyError extends Error {
   constructor(message?: string) {
     super(message || "Invalid BasicMessage body Error");
   }

--- a/src/pollux/models/AnonCredsVerifiableCredential.ts
+++ b/src/pollux/models/AnonCredsVerifiableCredential.ts
@@ -9,7 +9,7 @@ export enum AnonCredsCredentialProperties {
   sub = "sub",
   credentialDefinitionId = "credentialDefinitionId",
   values = "values",
-  signasture = "signature",
+  signature = "signature",
   signatureCorrectnessProof = "signatureCorrectnessProof",
   exp = "exp",
 }
@@ -42,7 +42,7 @@ export class AnonCredsCredential
     );
     this.properties.set(AnonCredsCredentialProperties.values, values);
 
-    this.properties.set(AnonCredsCredentialProperties.signasture, signature);
+    this.properties.set(AnonCredsCredentialProperties.signature, signature);
     this.properties.set(
       AnonCredsCredentialProperties.signatureCorrectnessProof,
       signature_correctness_proof

--- a/src/prism-agent/helpers/ProtocolHelpers.ts
+++ b/src/prism-agent/helpers/ProtocolHelpers.ts
@@ -123,7 +123,7 @@ export class ProtocolHelpers {
 
     if (this.isBasicMessageBody(type, parsed)) {
       if (parsed.content && typeof parsed.content !== "string") {
-        throw new AgentError.InvalidBasicMEssageBodyError("Invalid content");
+        throw new AgentError.InvalidBasicMessageBodyError("Invalid content");
       }
       return {
         content: parsed.content,

--- a/src/prism-agent/protocols/other/BasicMessage.ts
+++ b/src/prism-agent/protocols/other/BasicMessage.ts
@@ -24,7 +24,7 @@ export class BasicMessage {
       !fromMessage.from ||
       !fromMessage.to
     ) {
-      throw new AgentError.InvalidBasicMEssageBodyError(
+      throw new AgentError.InvalidBasicMessageBodyError(
         "Invalid BasicMessage body error."
       );
     }


### PR DESCRIPTION
# Description

Updating a couple of known Typos.
These are technically internal to the SDK so shouldn't break downstream, but as they are exported it's possible.

  - update classname `InvalidBasicMEssageBodyError` to `InvalidBasicMessageBodyError`
  - update property of `AnonCredsCredentialProperties`: `signasture` to `signature`

# Jira link
https://input-output.atlassian.net/browse/ATL-6313


# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
