### PR TITLE
fix: Removing the extra master branch from the production release

### DIFF
--- a/release-prod.config.js
+++ b/release-prod.config.js
@@ -1,7 +1,6 @@
 const baseConfig = require('./release.base.config');
 module.exports = baseConfig({
     branches: [
-        'master',
         {
             name: 'release/*',
         }


### PR DESCRIPTION

# Description
We are trying to fix the release not creating automatically, and we suspect it is not happening because we are using 2 branches and the release is happening on a different channel, not "default".


