### PR TITLE
fix: Recover JTI field correctly. Allowing to regenerate the original JWT string

### DIFF
--- a/src/pollux/models/JWTVerifiableCredential.ts
+++ b/src/pollux/models/JWTVerifiableCredential.ts
@@ -20,8 +20,7 @@ export const JWTVerifiableCredentialRecoveryId = "jwt+credential";
 
 export class JWTCredential
   extends Credential
-  implements ProvableCredential, StorableCredential
-{
+  implements ProvableCredential, StorableCredential {
   public credentialType = CredentialType.JWT;
   public recoveryId = JWTVerifiableCredentialRecoveryId;
   public properties = new Map<JWTVerifiableCredentialProperties, any>();
@@ -41,7 +40,7 @@ export class JWTCredential
     public readonly originalJWTString?: string
   ) {
     super();
-
+    this.properties.set(JWTVerifiableCredentialProperties.jti, jti);
     this.properties.set(JWTVerifiableCredentialProperties.iss, iss);
     this.properties.set(JWTVerifiableCredentialProperties.sub, sub);
     this.properties.set(JWTVerifiableCredentialProperties.nbf, nbf);
@@ -143,7 +142,7 @@ export class JWTCredential
     const credentialData = JSON.stringify(Object.fromEntries(this.properties));
 
     return {
-      id: this.getProperty(JWTVerifiableCredentialProperties.jti),
+      id: this.jti || this.getProperty(JWTVerifiableCredentialProperties.jti),
       recoveryId: this.recoveryId,
       credentialData: credentialData,
       issuer: this.getProperty(JWTVerifiableCredentialProperties.iss),

--- a/tests/pollux/Pollux.test.ts
+++ b/tests/pollux/Pollux.test.ts
@@ -356,6 +356,21 @@ describe("Pollux", () => {
         expect(result.issuanceDate).to.equal(issuanceDate);
         expect(result.expirationDate).to.equal(expirationDate);
       });
+
+      it("should be able to recover JTI from a toStorable", async () => {
+        const result = await pollux.parseCredential(
+          Buffer.from(Fixtures.Credentials.JWT.credentialPayloadEncoded),
+          {
+            type: CredentialType.JWT,
+          }
+        ) as JWTCredential;
+
+        const storable = result.toStorable();
+
+        expect(storable).to.be.an("object");
+        expect(storable).to.have.property("id");
+        expect(storable.id).to.equal(Fixtures.Credentials.JWT.credentialPayloadEncoded);
+      });
     });
   });
 


### PR DESCRIPTION

# Description
Fixes https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/issues/170



# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [ ] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
