### PR TITLE
bug: fix issuanceDate out by 1000

### DIFF
--- a/src/pollux/models/JWTVerifiableCredential.ts
+++ b/src/pollux/models/JWTVerifiableCredential.ts
@@ -106,7 +106,7 @@ export class JWTCredential
   }
 
   get issuanceDate() {
-    return new Date(this.nbf).toISOString();
+    return new Date(this.nbf*1000).toISOString();
   }
 
   get issuer() {


### PR DESCRIPTION
Found the dates coming out of credential.issuanceDate were wrong. Investigating noticed the numbers were out by 1000!

reading the JWT spec we see that nbf if in NumericDate (in seconds, no t microseconds): https://www.rfc-editor.org/rfc/rfc75

Likely this will need tests fixing. I'll leave that in your hands though :heart: 