### PR TITLE
fix: Removing the if condition in CI pipeline for release branches

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,7 +82,6 @@ jobs:
           scope: "@hyperledger-labs"
 
       - name: Pack atala-prism-wallet-sdk
-        if: github.event_name == 'pull_request'
         run: |
           npm install
           npm run build
@@ -90,7 +89,6 @@ jobs:
           echo "PACKAGE_NAME=$(find . -maxdepth 1 -name atala-prism-wallet-sdk-* | tr -d '\n')" >> "$GITHUB_ENV"
   
       - name: Install local dependency
-        if: github.event_name == 'pull_request'
         working-directory: integration-tests/e2e-tests
         run: |
           yarn


### PR DESCRIPTION

# Description
The release branches never are included in a pull request, they exist by cherry-picking and then we deploy the version and as soon as the tags have been pushed by the CI task the release branch can be removed if needed.

I have identified that if we don't have a pull request open the CI pipeline for e2e tests will not be running the build, pack + install. 



# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
