### PR TITLE
fix: db cannot be created twice with the same name which crashes demos

### DIFF
--- a/src/pluto/rxdb/Store.ts
+++ b/src/pluto/rxdb/Store.ts
@@ -7,6 +7,7 @@ import { Model } from '../models';
 import { RxDBEncryptedMigrationPlugin } from '../migration';
 import { Domain } from '../..';
 import { RxDBUpdatePlugin } from 'rxdb/plugins/update';
+
 export class RxdbStore implements Pluto.Store {
   private _db?: RxDatabase<CollectionsOfDatabase, any, any>;
 
@@ -33,13 +34,14 @@ export class RxdbStore implements Pluto.Store {
    * Start the database and build collections
    */
   async start(): Promise<void> {
-    this._db = await createRxDatabase({
-      ...this.options,
-      multiInstance: true,
-      ignoreDuplicate: true
-    });
-    const collections = makeCollections(this.collections ?? {});
-    await this._db.addCollections(collections);
+    if (!this._db) {
+      this._db = await createRxDatabase({
+        ...this.options,
+        multiInstance: true
+      });
+      const collections = makeCollections(this.collections ?? {});
+      await this._db.addCollections(collections);
+    }
   }
 
   async update<T extends Domain.Pluto.Storable>(name: string, model: T): Promise<void> {

--- a/src/pluto/rxdb/Store.ts
+++ b/src/pluto/rxdb/Store.ts
@@ -35,7 +35,8 @@ export class RxdbStore implements Pluto.Store {
   async start(): Promise<void> {
     this._db = await createRxDatabase({
       ...this.options,
-      multiInstance: true
+      multiInstance: true,
+      ignoreDuplicate: true
     });
     const collections = makeCollections(this.collections ?? {});
     await this._db.addCollections(collections);


### PR DESCRIPTION

### Description: 
Found a bug in our pluto implementation which is leading to databases not being usable. The user's in the browser usually would setup a single database name and work on that single DB. RXDB is not allowing that because second time u create the database it will already exist.

This fixes the issue.

No JIRA Ticket.

### Checklist: 
- [] My PR follows the contribution guidelines of this project
- [] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)