### PR TITLE
fix: optin to websockets for the mediator live mode as an experiment,…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,8 +28,10 @@
         "${fileBasenameNoExtension}",
         "--colors",
         "--workerThreads",
+        "--detectOpenHandles",
         "--maxWorkers",
-        "1"
+        "1",
+        "./tests"
       ],
       "skipFiles": [
         "${workspaceRoot}/../../node_modules/**/*",

--- a/src/prism-agent/Agent.ts
+++ b/src/prism-agent/Agent.ts
@@ -11,6 +11,7 @@ import {
   AgentCredentials as AgentCredentialsClass,
   AgentDIDHigherFunctions as AgentDIDHigherFunctionsClass,
   AgentInvitations as AgentInvitationsClass,
+  AgentOptions,
   EventCallback,
   InvitationType,
   ListenerKey,
@@ -86,8 +87,10 @@ export default class Agent
     public readonly mediationHandler: MediatorHandler,
     public readonly connectionManager: ConnectionsManager,
     public readonly seed: Domain.Seed = apollo.createRandomSeed().seed,
-    public readonly api: Domain.Api = new ApiImpl()
+    public readonly api: Domain.Api = new ApiImpl(),
+    options?: AgentOptions
   ) {
+
     this.pollux = new Pollux(castor);
     this.agentCredentials = new AgentCredentials(
       apollo,
@@ -104,7 +107,8 @@ export default class Agent
         pluto,
         this.agentCredentials,
         mediationHandler,
-        []
+        [],
+        options
       );
 
 
@@ -147,6 +151,7 @@ export default class Agent
     castor?: Domain.Castor;
     mercury?: Domain.Mercury;
     seed?: Domain.Seed;
+    options?: AgentOptions
   }): Agent {
     const mediatorDID = Domain.DID.from(params.mediatorDID);
     const pluto = params.pluto;
@@ -170,7 +175,15 @@ export default class Agent
       pollux,
       seed
     );
-    const manager = new ConnectionsManager(castor, mercury, pluto, agentCredentials, handler);
+    const manager = new ConnectionsManager(
+      castor,
+      mercury,
+      pluto,
+      agentCredentials,
+      handler,
+      [],
+      params.options
+    );
 
     const agent = new Agent(
       apollo,
@@ -180,7 +193,8 @@ export default class Agent
       handler,
       manager,
       seed,
-      api
+      api,
+      params.options
     );
 
     return agent;
@@ -217,7 +231,8 @@ export default class Agent
     mercury: Domain.Mercury,
     connectionManager: ConnectionsManager,
     seed?: Domain.Seed,
-    api?: Domain.Api
+    api?: Domain.Api,
+    options?: AgentOptions
   ) {
     return new Agent(
       apollo,
@@ -227,7 +242,8 @@ export default class Agent
       connectionManager.mediationHandler,
       connectionManager,
       seed ? seed : apollo.createRandomSeed().seed,
-      api ? api : new ApiImpl()
+      api ? api : new ApiImpl(),
+      options
     );
   }
 

--- a/src/prism-agent/connectionsManager/ConnectionsManager.ts
+++ b/src/prism-agent/connectionsManager/ConnectionsManager.ts
@@ -1,4 +1,3 @@
-import { uuid } from "@stablelib/uuid";
 import { DID, Message, MessageDirection, Pollux } from "../../domain";
 import { Castor } from "../../domain/buildingBlocks/Castor";
 import { Mercury } from "../../domain/buildingBlocks/Mercury";
@@ -74,7 +73,7 @@ export class ConnectionsManager implements ConnectionsManagerClass {
     public agentCredentials: AgentCredentials,
     public mediationHandler: MediatorHandler,
     public pairings: DIDPair[] = [],
-    private options?: AgentOptions
+    public options?: AgentOptions
   ) {
     this.events = new AgentMessageEvents();
   }

--- a/src/prism-agent/helpers/Task.ts
+++ b/src/prism-agent/helpers/Task.ts
@@ -1,9 +1,5 @@
 type Task<T> = (signal: AbortSignal) => Promise<T>;
 
-
-
-
-
 export class CancellableTask<T> {
   private period?: number;
   private controller: AbortController;

--- a/src/prism-agent/types/index.ts
+++ b/src/prism-agent/types/index.ts
@@ -118,6 +118,7 @@ export interface ConnectionsManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   cancellables: CancellableTask<any>[];
 
+  withWebsocketsExperiment: boolean;
   stopAllEvents(): void;
 
   addConnection(paired: DIDPair): Promise<void>;

--- a/src/prism-agent/types/index.ts
+++ b/src/prism-agent/types/index.ts
@@ -28,6 +28,13 @@ export enum InvitationTypes {
   PRISM_ONBOARD,
 }
 
+
+export type AgentOptions = {
+  experiments?: {
+    liveMode?: boolean
+  }
+}
+
 export type InvitationType = PrismOnboardingInvitation | OutOfBandInvitation;
 
 export class PrismOnboardingInvitation implements InvitationInterface {

--- a/tests/agent/Agent.ConnectionsManager.test.ts
+++ b/tests/agent/Agent.ConnectionsManager.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment node
+ */
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import SinonChai from "sinon-chai";
+import { Apollo, BasicMediatorHandler, Castor, ConnectionsManager, MediatorStore, Pluto } from "../../src";
+import { Curve, KeyTypes, Mercury, Service, ServiceEndpoint } from "../../src/domain";
+import { MercuryStub } from "./mocks/MercuryMock";
+import { AgentCredentials } from "../../src/prism-agent/Agent.Credentials";
+import { AgentOptions } from "../../src/prism-agent/types";
+
+chai.use(SinonChai);
+chai.use(chaiAsPromised);
+
+const store: MediatorStore = null as any;
+const mercury: Mercury = new MercuryStub();
+
+const apollo = new Apollo();
+const castor = new Castor(apollo)
+const pluto: Pluto = null as any;
+const agentCredentials: AgentCredentials = null as any;
+
+
+async function createBasicMediationHandler(
+    services: Service[],
+    options?: AgentOptions
+): Promise<
+    {
+        manager: ConnectionsManager,
+        handler: BasicMediatorHandler
+    }
+> {
+    const seed = apollo.createRandomSeed().seed;
+    const keypair = apollo.createPrivateKey({
+        type: KeyTypes.EC,
+        curve: Curve.SECP256K1,
+        seed: Buffer.from(seed.value).toString("hex"),
+    });
+    const mediatorDID = await castor.createPrismDID(keypair.publicKey(), services);
+    const handler = new BasicMediatorHandler(
+        mediatorDID,
+        mercury,
+        store
+    );
+    handler.mediator = {
+        hostDID: mediatorDID,
+        routingDID: mediatorDID,
+        mediatorDID: mediatorDID
+    }
+    return {
+        manager: new ConnectionsManager(
+            castor,
+            mercury,
+            pluto,
+            agentCredentials,
+            handler,
+            [],
+            options
+        ),
+        handler
+    }
+}
+
+
+describe("ConnectionsManager tests", () => {
+
+    beforeEach(() => {
+        jest.mock('isows', () => ({
+            WebSocket: jest.fn(() => ({
+                addEventListener: jest.fn(),
+                send: jest.fn(),
+                close: jest.fn(),
+            })),
+        }));
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("Should use websockets if the mediator's did endpoint uri contains ws or wss and agent options have the opt in", async () => {
+        const services = [
+            new Service(
+                "#didcomm-1",
+                ["DIDCommMessaging"],
+                new ServiceEndpoint("wss://localhost:12346")
+            )
+        ];
+        const { manager, handler } = await createBasicMediationHandler(
+            services,
+            {
+                experiments: {
+                    liveMode: true
+                }
+            }
+        );
+        const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
+        expect(manager).toHaveProperty('withWebsocketsExperiment', true);
+        await manager.startFetchingMessages(1)
+        expect(listenUnread).toHaveBeenCalled();
+    })
+
+    it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in", async () => {
+        const services = [
+            new Service(
+                "#didcomm-1",
+                ["DIDCommMessaging"],
+                new ServiceEndpoint("wss://localhost:12346")
+            )
+        ];
+        const { manager, handler } = await createBasicMediationHandler(
+            services
+        );
+        const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
+        expect(manager).toHaveProperty('withWebsocketsExperiment', false);
+
+        await manager.startFetchingMessages(1)
+
+        expect(listenUnread).not.toHaveBeenCalled()
+    })
+
+    it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in 1", async () => {
+        const services = [
+            new Service(
+                "#didcomm-1",
+                ["DIDCommMessaging"],
+                new ServiceEndpoint("wss://localhost:12346")
+            )
+        ];
+        const { manager, handler } = await createBasicMediationHandler(
+            services,
+            {
+                experiments: {
+
+                }
+            }
+        );
+        const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
+        expect(manager).toHaveProperty('withWebsocketsExperiment', false);
+
+        await manager.startFetchingMessages(1)
+
+        expect(listenUnread).not.toHaveBeenCalled()
+    })
+
+    it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in 2", async () => {
+        const services = [
+            new Service(
+                "#didcomm-1",
+                ["DIDCommMessaging"],
+                new ServiceEndpoint("wss://localhost:12346")
+            )
+        ];
+        const { manager, handler } = await createBasicMediationHandler(
+            services,
+            {
+                experiments: {
+                    liveMode: false
+                }
+            }
+        );
+        const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
+        expect(manager).toHaveProperty('withWebsocketsExperiment', false);
+
+        await manager.startFetchingMessages(1)
+
+        expect(listenUnread).not.toHaveBeenCalled()
+    })
+
+    it("Should not use websockets if the mediator'd did endpoint uri does not contain ws or wss for more than the agent has opted in", async () => {
+        const services = [
+            new Service(
+                "#didcomm-1",
+                ["DIDCommMessaging"],
+                new ServiceEndpoint("http://localhost:12346")
+            )
+        ];
+        const { manager, handler } = await createBasicMediationHandler(
+            services,
+            {
+                experiments: {
+                    liveMode: true
+                }
+            }
+        );
+        const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
+        expect(manager).toHaveProperty('withWebsocketsExperiment', true);
+
+        await manager.startFetchingMessages(1)
+
+        expect(listenUnread).not.toHaveBeenCalled()
+    })
+
+})

--- a/tests/agent/Agent.ConnectionsManager.test.ts
+++ b/tests/agent/Agent.ConnectionsManager.test.ts
@@ -23,6 +23,8 @@ const agentCredentials: AgentCredentials = null as any;
 
 
 async function createBasicMediationHandler(
+    ConnectionsManager: any,
+    BasicMediatorHandler: any,
     services: Service[],
     options?: AgentOptions
 ): Promise<
@@ -31,6 +33,7 @@ async function createBasicMediationHandler(
         handler: BasicMediatorHandler
     }
 > {
+
     const seed = apollo.createRandomSeed().seed;
     const keypair = apollo.createPrivateKey({
         type: KeyTypes.EC,
@@ -48,16 +51,17 @@ async function createBasicMediationHandler(
         routingDID: mediatorDID,
         mediatorDID: mediatorDID
     }
+    const manager = new ConnectionsManager(
+        castor,
+        mercury,
+        pluto,
+        agentCredentials,
+        handler,
+        [],
+        options
+    )
     return {
-        manager: new ConnectionsManager(
-            castor,
-            mercury,
-            pluto,
-            agentCredentials,
-            handler,
-            [],
-            options
-        ),
+        manager,
         handler
     }
 }
@@ -84,10 +88,14 @@ describe("ConnectionsManager tests", () => {
             new Service(
                 "#didcomm-1",
                 ["DIDCommMessaging"],
-                new ServiceEndpoint("wss://localhost:12346")
+                new ServiceEndpoint("ws://localhost:12346")
             )
         ];
+        const ConnectionsManager = jest.requireActual('../../src/prism-agent/connectionsManager/ConnectionsManager').ConnectionsManager;
+        const BasicMediatorHandler = jest.requireMock('../../src/prism-agent/mediator/BasicMediatorHandler').BasicMediatorHandler;
         const { manager, handler } = await createBasicMediationHandler(
+            ConnectionsManager,
+            BasicMediatorHandler,
             services,
             {
                 experiments: {
@@ -99,6 +107,8 @@ describe("ConnectionsManager tests", () => {
         expect(manager).toHaveProperty('withWebsocketsExperiment', true);
         await manager.startFetchingMessages(1)
         expect(listenUnread).toHaveBeenCalled();
+
+        manager.stopFetchingMessages()
     })
 
     it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in", async () => {
@@ -106,10 +116,14 @@ describe("ConnectionsManager tests", () => {
             new Service(
                 "#didcomm-1",
                 ["DIDCommMessaging"],
-                new ServiceEndpoint("wss://localhost:12346")
+                new ServiceEndpoint("ws://localhost:12346")
             )
         ];
+        const ConnectionsManager = jest.requireActual('../../src/prism-agent/connectionsManager/ConnectionsManager').ConnectionsManager;
+        const BasicMediatorHandler = jest.requireMock('../../src/prism-agent/mediator/BasicMediatorHandler').BasicMediatorHandler;
         const { manager, handler } = await createBasicMediationHandler(
+            ConnectionsManager,
+            BasicMediatorHandler,
             services
         );
         const listenUnread = jest.spyOn(handler, 'listenUnreadMessages')
@@ -118,6 +132,7 @@ describe("ConnectionsManager tests", () => {
         await manager.startFetchingMessages(1)
 
         expect(listenUnread).not.toHaveBeenCalled()
+        manager.stopFetchingMessages()
     })
 
     it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in 1", async () => {
@@ -125,10 +140,14 @@ describe("ConnectionsManager tests", () => {
             new Service(
                 "#didcomm-1",
                 ["DIDCommMessaging"],
-                new ServiceEndpoint("wss://localhost:12346")
+                new ServiceEndpoint("ws://localhost:12346")
             )
         ];
+        const ConnectionsManager = jest.requireActual('../../src/prism-agent/connectionsManager/ConnectionsManager').ConnectionsManager;
+        const BasicMediatorHandler = jest.requireMock('../../src/prism-agent/mediator/BasicMediatorHandler').BasicMediatorHandler;
         const { manager, handler } = await createBasicMediationHandler(
+            ConnectionsManager,
+            BasicMediatorHandler,
             services,
             {
                 experiments: {
@@ -142,6 +161,7 @@ describe("ConnectionsManager tests", () => {
         await manager.startFetchingMessages(1)
 
         expect(listenUnread).not.toHaveBeenCalled()
+        manager.stopFetchingMessages()
     })
 
     it("Should not use websockets even if the mediator's did endpoint uri contains ws or wss if the agent options don't have the opt-in 2", async () => {
@@ -149,10 +169,14 @@ describe("ConnectionsManager tests", () => {
             new Service(
                 "#didcomm-1",
                 ["DIDCommMessaging"],
-                new ServiceEndpoint("wss://localhost:12346")
+                new ServiceEndpoint("ws://localhost:12346")
             )
         ];
+        const ConnectionsManager = jest.requireActual('../../src/prism-agent/connectionsManager/ConnectionsManager').ConnectionsManager;
+        const BasicMediatorHandler = jest.requireMock('../../src/prism-agent/mediator/BasicMediatorHandler').BasicMediatorHandler;
         const { manager, handler } = await createBasicMediationHandler(
+            ConnectionsManager,
+            BasicMediatorHandler,
             services,
             {
                 experiments: {
@@ -166,6 +190,7 @@ describe("ConnectionsManager tests", () => {
         await manager.startFetchingMessages(1)
 
         expect(listenUnread).not.toHaveBeenCalled()
+        manager.stopFetchingMessages()
     })
 
     it("Should not use websockets if the mediator'd did endpoint uri does not contain ws or wss for more than the agent has opted in", async () => {
@@ -176,7 +201,11 @@ describe("ConnectionsManager tests", () => {
                 new ServiceEndpoint("http://localhost:12346")
             )
         ];
+        const ConnectionsManager = jest.requireActual('../../src/prism-agent/connectionsManager/ConnectionsManager').ConnectionsManager;
+        const BasicMediatorHandler = jest.requireMock('../../src/prism-agent/mediator/BasicMediatorHandler').BasicMediatorHandler;
         const { manager, handler } = await createBasicMediationHandler(
+            ConnectionsManager,
+            BasicMediatorHandler,
             services,
             {
                 experiments: {
@@ -190,6 +219,7 @@ describe("ConnectionsManager tests", () => {
         await manager.startFetchingMessages(1)
 
         expect(listenUnread).not.toHaveBeenCalled()
+        manager.stopFetchingMessages()
     })
 
 })

--- a/tests/agent/Agent.test.ts
+++ b/tests/agent/Agent.test.ts
@@ -60,10 +60,7 @@ let pluto: IPluto;
 let pollux: Pollux;
 let castor: Castor;
 let sandbox: sinon.SinonSandbox;
-let store: Pluto.Store
-// jest.mock("../apollo/utils/jwt/JWT", () => () => ({
-//   sign: jest.fn(() => "")
-// }));
+let store: Pluto.Store;
 
 
 describe("Agent Tests", () => {
@@ -76,7 +73,13 @@ describe("Agent Tests", () => {
 
   beforeEach(async () => {
     jest.useFakeTimers();
-
+    jest.mock('isows', () => ({
+      WebSocket: jest.fn(() => ({
+        addEventListener: jest.fn(),
+        send: jest.fn(),
+        close: jest.fn(),
+      })),
+    }));
     sandbox = sinon.createSandbox();
     const apollo: Apollo = new Apollo();
     castor = CastorMock;
@@ -109,7 +112,12 @@ describe("Agent Tests", () => {
       castor,
       mercury,
       pluto,
-      agentCredentials
+      agentCredentials,
+      options: {
+        experiments: {
+          liveMode: false
+        }
+      }
     })
 
 
@@ -118,7 +126,13 @@ describe("Agent Tests", () => {
       castor,
       pluto,
       mercury,
-      connectionsManager
+      connectionsManager,
+      undefined, undefined,
+      {
+        experiments: {
+          liveMode: false
+        }
+      }
     );
 
     await polluxInstance.start();

--- a/tests/agent/Agent.test.ts
+++ b/tests/agent/Agent.test.ts
@@ -105,10 +105,14 @@ describe("Agent Tests", () => {
       apollo.createRandomSeed().seed
     )
 
-    const connectionsManager = new ConnectionsManagerMock(
-      castor, mercury, pluto, agentCredentials
+    const connectionsManager = ConnectionsManagerMock.buildMock({
+      castor,
+      mercury,
+      pluto,
+      agentCredentials
+    })
 
-    );
+
     agent = Agent.instanceFromConnectionManager(
       apollo,
       castor,

--- a/tests/agent/mocks/ConnectionManagerMock.ts
+++ b/tests/agent/mocks/ConnectionManagerMock.ts
@@ -55,6 +55,7 @@ export class ConnectionsManagerMock implements ConnectionsManagerClass {
     this.mediationHandler = this.manager.mediationHandler;
   }
 
+
   static buildMock(params: Partial<ConnectionMockConstructor>): ConnectionsManagerMock {
     const mediationHandler: MediatorHandler = {
       registerMessagesAsRead: async () => { },

--- a/tests/agent/mocks/ConnectionManagerMock.ts
+++ b/tests/agent/mocks/ConnectionManagerMock.ts
@@ -1,6 +1,8 @@
 import {
   AgentCredentials,
+  AgentOptions,
   ConnectionsManager as ConnectionsManagerClass,
+  EventCallback,
   MediatorHandler,
 } from "../../../src/prism-agent/types";
 import { Castor } from "../../../src/domain/buildingBlocks/Castor";
@@ -8,24 +10,37 @@ import { Mercury } from "../../../src/domain/buildingBlocks/Mercury";
 import { Pluto } from "../../../src/domain/buildingBlocks/Pluto";
 import { DIDPair } from "../../../src/domain/models/DIDPair";
 import { CancellableTask } from "../../../src/prism-agent/helpers/Task";
-import { DID, Message, Pollux } from "../../../src/domain";
+import { DID, Mediator, Message, Pollux } from "../../../src/domain";
 import { AgentMessageEvents } from "../../../src/prism-agent/Agent.MessageEvents";
 import { ConnectionsManager } from "../../../src";
 
+
+
+type ConnectionMockConstructor = {
+  castor: Castor,
+  mercury: Mercury,
+  pluto: Pluto,
+  agentCredentials: AgentCredentials,
+  mediationHandler: MediatorHandler,
+  pairings?: DIDPair[],
+  options?: AgentOptions
+}
+
+
 export class ConnectionsManagerMock implements ConnectionsManagerClass {
   private manager: ConnectionsManagerClass;
+  public options?: AgentOptions
 
   constructor(
-    castor: Castor,
-    mercury: Mercury,
-    pluto: Pluto,
-    agentCredentials: AgentCredentials
+    params: ConnectionMockConstructor
   ) {
+    const { castor, mercury, pluto, agentCredentials, options } = params
 
     this.castor = castor;
     this.mercury = mercury;
     this.pluto = pluto;
     this.agentCredentials = agentCredentials;
+    this.options = options;
 
     const connManager = new ConnectionsManager(
       this.castor,
@@ -33,10 +48,62 @@ export class ConnectionsManagerMock implements ConnectionsManagerClass {
       this.pluto,
       this.agentCredentials,
       this.mediationHandler,
-      this.pairings
+      [],
+      options
     )
     this.manager = connManager;
     this.mediationHandler = this.manager.mediationHandler;
+  }
+
+  static buildMock(params: Partial<ConnectionMockConstructor>): ConnectionsManagerMock {
+    const mediationHandler: MediatorHandler = {
+      registerMessagesAsRead: async () => { },
+      updateKeyListWithDIDs: async () => { },
+      mediator: {
+        mediatorDID: new DID(
+          "did",
+          "peer",
+          "2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
+        ),
+        hostDID: new DID(
+          "did",
+          "peer",
+          "2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
+        ),
+        routingDID: new DID(
+          "did",
+          "peer",
+          "2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
+        ),
+      },
+      mediatorDID: new DID(
+        "did",
+        "peer",
+        "2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
+      ),
+      bootRegisteredMediator: function (): Promise<Mediator | undefined> {
+        throw new Error("Mock bootRegisteredMediator Function not implemented.");
+      },
+      achieveMediation: function (host: DID): Promise<Mediator> {
+        throw new Error("Mock achieveMediation Function not implemented.");
+      },
+      pickupUnreadMessages: function (limit: number): Promise<{ attachmentId: string; message: Message; }[]> {
+        throw new Error("Mock pickupUnreadMessages Function not implemented.");
+      },
+      listenUnreadMessages: function (signal: AbortSignal, serviceEndpointUri: string, onMessage: EventCallback): void {
+        throw new Error("Mock listenUnreadMessages Function not implemented.");
+      }
+    };
+
+    params.mediationHandler = mediationHandler;
+
+    return new ConnectionsManagerMock(
+      params as ConnectionMockConstructor
+    )
+  }
+
+  get withWebsocketsExperiment() {
+    return this.options?.experiments?.liveMode === true
   }
 
   processMessages(messages: { attachmentId: string; message: Message; }[]): Promise<void> {


### PR DESCRIPTION


### Description: 
Disabling mediator live mode by default and enabling it as an optional experiment developers must opt-in, VS being enabled by default

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
