### PR TITLE
fix: type references are lost in the package.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-import * as SDK from './src';
+import * as SDK from './build/typings';
 
 export default SDK


### PR DESCRIPTION
### Description: 
Simple fix that fixes the types from not being available to users that don't have all the resource.

We had already detected this but the change is in a PR that is not yet merged. So I prefer not to rush and include  the change directly in this small PR. 

This change should go out as soon as possible.



### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
