### PR TITLE
fix: add compliant dates not in ms, but in seconds.

### DIFF
--- a/src/pollux/models/JWTVerifiableCredential.ts
+++ b/src/pollux/models/JWTVerifiableCredential.ts
@@ -320,14 +320,14 @@ export class JWTCredential
     const exp = this.isCredentialPayload(Object.fromEntries(this.properties)) ?
       this.properties.get(JWT_VC_PROPS.exp) :
       this.properties.get(JWT_VP_PROPS.exp);
-    return exp ? new Date(exp).toISOString() : undefined;
+    return exp ? new Date(exp * 1000).toISOString() : undefined;
   }
 
   get issuanceDate() {
     const nbf = this.isCredentialPayload(Object.fromEntries(this.properties)) ?
       this.properties.get(JWT_VC_PROPS.nbf) :
       this.properties.get(JWT_VP_PROPS.nbf);
-    return new Date(nbf).toISOString();
+    return new Date(nbf * 1000).toISOString();
   }
 
   get audience() {

--- a/tests/pollux/Pollux.test.ts
+++ b/tests/pollux/Pollux.test.ts
@@ -393,10 +393,10 @@ describe("Pollux", () => {
             credential.credentialSubject
           );
           expect(jwtCred.expirationDate).to.be.equal(
-            new Date(jwtPayload[JWTVerifiableCredentialProperties.exp]).toISOString()
+            new Date(jwtPayload[JWTVerifiableCredentialProperties.exp] * 1000).toISOString()
           );
           expect(jwtCred.issuanceDate).to.be.equal(
-            new Date(jwtPayload[JWTVerifiableCredentialProperties.nbf]).toISOString()
+            new Date(jwtPayload[JWTVerifiableCredentialProperties.nbf] * 1000).toISOString()
           );
 
           expect(jwtCred.type).to.be.deep.equal(credential.type);
@@ -428,8 +428,8 @@ describe("Pollux", () => {
           }
         ) as JWTCredential;
 
-        const issuanceDate = new Date(nbf).toISOString();
-        const expirationDate = new Date(exp).toISOString();
+        const issuanceDate = new Date(nbf * 1000).toISOString();
+        const expirationDate = new Date(exp * 1000).toISOString();
 
         expect(result.issuanceDate).to.equal(issuanceDate);
         expect(result.expirationDate).to.equal(expirationDate);


### PR DESCRIPTION
### Description: 
In our current 2.12 release we have introduced multiple breaking changes into the JWT classes and https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/pull/175 that PR now has some conflicts.

The JWT specification states issuance and expiration dates as numbers, and we were generating dates using the number of seconds not ms

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
