### PR TITLE
docs: updates documentation to use sdk folder

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,0 +1,5 @@
+<head>
+  <meta http-equiv='refresh' content='0; URL=/atala-prism-wallet-sdk-ts/sdk/'/>
+</head>
+
+Redirecting to `/atala-prism-wallet-sdk-ts/sdk/`.

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,3 +1,5 @@
+@atala/prism-wallet-sdk / [Exports](modules.md)
+
 # Identus TypeScript SDK
 
 [![Coverage Status](https://coveralls.io/repos/github/input-output-hk/atala-prism-wallet-sdk-ts/badge.svg?branch=master)](https://coveralls.io/github/input-output-hk/atala-prism-wallet-sdk-ts?branch=master)
@@ -102,5 +104,4 @@ This SDK exposes Pluto, a storage interface that should be implemented by the us
 
 We don't provide a default implementation out of the box at the moment, but we do provide a couple of demo implementations that can be used to get started with demos and testing. 
 
-Provided demo implementations are intentionally oversimplified and SHOULD NOT be used in production. 
-
+Provided demo implementations are intentionally oversimplified and SHOULD NOT be used in production.

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -104,4 +104,4 @@ This SDK exposes Pluto, a storage interface that should be implemented by the us
 
 We don't provide a default implementation out of the box at the moment, but we do provide a couple of demo implementations that can be used to get started with demos and testing. 
 
-Provided demo implementations are intentionally oversimplified and SHOULD NOT be used in production.
+Provided demo implementations are intentionally oversimplified and **should not** be used in production.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -7,7 +7,7 @@ const sidebars = {
         {
             label: 'Introduction',
             type: "doc",
-            id: "README"
+            id: "sdk/README"
         },
         {
             type: 'category',
@@ -59,9 +59,8 @@ const sidebars = {
                                     ...files.map((filename) => {
 
                                         const fixFile = `sdk/${currentFolder}/${filename.replace(".md", "")}`
-                                        console.log(fixFile)
                                         return {
-                                            label: fixFile.replace(`${currentFolder}/Domain.`, ""),
+                                            label: fixFile.replace(`sdk/${currentFolder}/Domain.`, ""),
                                             type: "doc",
                                             id: fixFile
                                         }
@@ -94,7 +93,7 @@ const sidebars = {
                                     ...files.map((filename) => {
                                         const fixFile = `sdk/${currentFolder}/${filename.replace(".md", "")}`
                                         return {
-                                            label: fixFile.replace(`${currentFolder}/`, ""),
+                                            label: fixFile.replace(`sdk/${currentFolder}/`, ""),
                                             type: "doc",
                                             id: fixFile
                                         }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
     "test": "jest",
     "coverage": "npm run test -- --coverage",
     "lint": "npx eslint .",
-    "docs": "npm run docs:readme; npm run docs:typedoc",
-    "docs:typedoc": "npx typedoc --options typedoc.js --hideGenerator",
-    "docs:readme": "cp README.md docs/README.md"
+    "docs": "npx typedoc --options typedoc.js"
   },
   "author": "IOHK",
   "repository": {


### PR DESCRIPTION
### Description: 
- Updates the items in the sidebar from `sdk/Something` to `Something`
- Adds a redirect `README.mdx` from `/atala-prism-wallet-sdk-ts/` to `/atala-prism-wallet-sdk-ts/sdk` (simple workaround to about 404 if the person tries to enter manually the url)
- README.md is back as part of `docs/sdk/` folder
- Undo `docs` script change

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
