### PR TITLE
fix: Compatibility issues with osx and unix platforms around the sed

### DIFF
--- a/externals/run.sh
+++ b/externals/run.sh
@@ -23,6 +23,9 @@ anoncredsNewCommit=$(git submodule | grep $AnonCreds | awk '{print $1}')
 anoncredsOldCommit=$(cat "${ExternalsDir}/${AnonCreds}.commit" 2>/dev/null)
 anoncredsRequired=$?
 
+is_mac() {
+  [[ "$OSTYPE" == "darwin"* ]]
+}
 
 buildDIDComm() {
   echo "Build DIDComm"
@@ -39,7 +42,11 @@ buildDIDComm() {
   #This code fails on browser when wasm is first loaded, it can just be ignored
   #The code will fully work
   cd "${GenDIDComm}-wasm-browser"
-  sed -i '' "/if (typeof input === 'undefined') {/,/}/d" didcomm_js.js
+  if is_mac; then
+    sed -i '' "/if (typeof input === 'undefined') {/,/}/d" didcomm_js.js
+  else
+    sed -i "/if (typeof input === 'undefined') {/,/}/d" didcomm_js.js
+  fi
 
   cd $ExternalsDir
   git submodule | grep $DIDComm | awk '{print $1}' > "./${DIDComm}.commit"
@@ -64,8 +71,11 @@ buildAnonCreds() {
   #This code fails on browser when wasm is first loaded, it can just be ignored
   #The code will fully work
   cd "${GenAnonCreds}-wasm-browser"
-  sed -i '' "/if (typeof input === 'undefined') {/,/}/d" "./${AnonCreds}.js"
-
+  if is_mac; then
+    sed -i '' "/if (typeof input === 'undefined') {/,/}/d" "./${AnonCreds}.js"
+  else
+    sed -i "/if (typeof input === 'undefined') {/,/}/d" "./${AnonCreds}.js"
+  fi
   cd $ExternalsDir
   git submodule | grep $AnonCreds | awk '{print $1}' > "./${AnonCreds}.commit"
 }


### PR DESCRIPTION

### Description: 
Fixes issue with sed commands, we have been having some regression issues around how libraries are built.
When wasm-pack builds the output for us, is generates :
```
if (typeof input === 'undefined') {
        input = new URL('anoncreds_bg.wasm', import.meta.url);
}
```

This peace of code is invalid and should be removed by the build command. 
We do this by running sed.

Please follow this article for more information: https://stackoverflow.com/questions/12696125/sed-edit-file-in-place

But we need to run different code depending on where the build is running from.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
