### PR TITLE
fix: create custom class to verify bitstring position more precisely.

### DIFF
--- a/src/pollux/Pollux.ts
+++ b/src/pollux/Pollux.ts
@@ -60,6 +60,7 @@ import { HttpStatusCode } from "axios";
 import { JsonLd, RemoteDocument } from "jsonld/jsonld-spec";
 import { VerificationKeyType } from "../castor/types";
 import { revocationJsonldDocuments } from "../domain/models/revocation";
+import { Bitstring } from "./utils/Bitstring";
 
 /**
  * Implementation of Pollux
@@ -165,6 +166,7 @@ export default class Pollux implements IPollux {
   private extractEncodedList(body: JWTStatusListResponse): Uint8Array {
     try {
       const encodedList = Buffer.from(body.credentialSubject.encodedList, 'base64');
+
       return this._pako.ungzip(encodedList);
     } catch (err) {
       throw new PolluxError.InvalidRevocationStatusResponse(`Couldn't ungzip base64 encoded list, err: ${(err as Error).message}`)
@@ -264,8 +266,8 @@ export default class Pollux implements IPollux {
           throw new PolluxError.InvalidRevocationStatusResponse(`CredentialStatus invalid signature`);
         }
         const statusListDecoded = this.extractEncodedList(revocation)
-        const isRevoked = statusListDecoded[statusListIndex] !== 0
-        return isRevoked
+        const bitstring = new Bitstring({ buffer: statusListDecoded })
+        return bitstring.get(statusListIndex + 1)
       }
       throw new PolluxError.InvalidRevocationStatusResponse(`CredentialStatus proof type not supported`);
     } catch (err) {

--- a/src/pollux/utils/Bitstring.ts
+++ b/src/pollux/utils/Bitstring.ts
@@ -1,0 +1,56 @@
+
+export class Bitstring {
+    bits: Uint8Array;
+    length: number;
+    leftToRightIndexing: boolean;
+
+    constructor({
+        buffer,
+        leftToRightIndexing
+    }: {
+        buffer: Uint8Array;
+        leftToRightIndexing?: boolean;
+    }) {
+        if (!buffer) {
+            throw new Error('Only one of "length" or "buffer" must be given.');
+        }
+        this.bits = new Uint8Array(buffer.buffer);
+        this.length = buffer.length * 8;
+        this.leftToRightIndexing = leftToRightIndexing ?? false;
+    }
+
+    set(position: number, on: boolean): void {
+        const { length, leftToRightIndexing } = this;
+        const { index, bit } = _parsePosition(position, length, leftToRightIndexing);
+        if (on) {
+            this.bits[index] |= bit;
+        } else {
+            this.bits[index] &= 0xff ^ bit;
+        }
+    }
+
+    get(position: number): boolean {
+        const { length, leftToRightIndexing } = this;
+        const { index, bit } = _parsePosition(position, length, leftToRightIndexing);
+        return !!(this.bits[index] & bit);
+    }
+
+
+}
+
+function _parsePosition(
+    position: number,
+    length: number,
+    leftToRightIndexing: boolean
+): { index: number; bit: number } {
+    if (position >= length) {
+        throw new Error(
+            `Position "${position}" is out of range "0-${length - 1}".`
+        );
+    }
+    const index = Math.floor(position / 8);
+    const rem = position % 8;
+    const shift = leftToRightIndexing ? 7 - rem : rem;
+    const bit = 1 << shift;
+    return { index, bit };
+}


### PR DESCRIPTION


### Description: 
just fixing and using a custom class now bitstring which is more precisely determining if the revocation is true or false. Earlier was checking that the revocation was not 0 but this is more concrete.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
