### PR TITLE
fix: attachment encoding fallback base64 + base64url by default

### DIFF
--- a/src/domain/models/Message.ts
+++ b/src/domain/models/Message.ts
@@ -11,7 +11,7 @@ import { AgentError } from "./Errors";
 import { CredentialType, JsonString } from ".";
 import { Pluto } from "../buildingBlocks/Pluto";
 import { JsonObj, asJsonObj, isArray, isNil, isObject, isString, notEmptyString, notNil } from "../../utils";
-import { base64 } from "multiformats/bases/base64";
+import { base64, base64url } from "multiformats/bases/base64";
 
 export enum MessageDirection {
   SENT = 0,
@@ -170,6 +170,13 @@ export class Message implements Pluto.Storable {
   }
 }
 
+const decodeBase64 = (data: string) => {
+  try {
+    return base64.baseDecode(data);
+  } catch (err) {
+    return base64url.baseDecode(data);
+  }
+}
 export namespace Message {
   export namespace Attachment {
     /**
@@ -180,7 +187,7 @@ export namespace Message {
      */
     export const extractJSON = (attachment: AttachmentDescriptor) => {
       if (isBase64(attachment.data)) {
-        const decoded = Buffer.from(base64.baseDecode(attachment.data.base64)).toString();
+        const decoded = Buffer.from(decodeBase64(attachment.data.base64)).toString();
         try {
           return JSON.parse(decoded);
         } catch (err) {


### PR DESCRIPTION


### Description: 
Adding base64 and base64url fallback in didcomm attachment extract fn's. earlier we were using Buffer which was able to handle cases where we get base64url and we should be getting base64.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
